### PR TITLE
Switch PI to M_PI to support STRICT_R_HEADERS

### DIFF
--- a/src/WN-1D.cpp
+++ b/src/WN-1D.cpp
@@ -41,7 +41,7 @@ arma::vec dWn1D(arma::vec x, double mu, double sigma, int maxK = 2, double expTr
 
   // Winding numbers
   int lk = 2 * maxK + 1;
-  arma::rowvec twokpi = arma::linspace<arma::rowvec>(-maxK * 2 * PI, maxK * 2 * PI, lk);
+  arma::rowvec twokpi = arma::linspace<arma::rowvec>(-maxK * 2 * M_PI, maxK * 2 * M_PI, lk);
 
   // 2 * variance and inverse
   double sd2 = 2 * sigma * sigma;
@@ -51,7 +51,7 @@ arma::vec dWn1D(arma::vec x, double mu, double sigma, int maxK = 2, double expTr
   x -= mu;
 
   // Log-normalizing constant
-  double lognormconstsd2 = -0.5 * log(PI * sd2);
+  double lognormconstsd2 = -0.5 * log(M_PI * sd2);
 
   /*
    * Computation of the density: wrapping
@@ -125,7 +125,7 @@ arma::vec dTpdWou1D(arma::vec x, arma::vec x0, double t, double alpha, double mu
 
   // Winding numbers
   int lk = 2 * maxK + 1;
-  arma::rowvec twokpi = arma::linspace<arma::rowvec>(-maxK * 2 * PI, maxK * 2 * PI, lk);
+  arma::rowvec twokpi = arma::linspace<arma::rowvec>(-maxK * 2 * M_PI, maxK * 2 * M_PI, lk);
 
   // Stationary variance (x 2)
   double sd2 = sigma * sigma / alpha;
@@ -137,7 +137,7 @@ arma::vec dTpdWou1D(arma::vec x, arma::vec x0, double t, double alpha, double mu
   double sd2t = sigma * sigma * (1 - exp(-2 * alpha * t)) / alpha;
 
   // Log-normalizing constant
-  double lognormconstsd2t = -0.5 * log(PI * sd2t);
+  double lognormconstsd2t = -0.5 * log(M_PI * sd2t);
 
   /*
    * Weights of the winding numbers for each data point

--- a/src/WN-2D.cpp
+++ b/src/WN-2D.cpp
@@ -103,7 +103,7 @@ arma::vec dTpdWou2D(arma::mat x, arma::mat x0, arma::vec t, arma::vec alpha, arm
 
   // Sequence of winding numbers
   int lk = 2 * maxK + 1;
-  arma::vec twokpi = arma::linspace<arma::vec>(-maxK * 2 * PI, maxK * 2 * PI, lk);
+  arma::vec twokpi = arma::linspace<arma::vec>(-maxK * 2 * M_PI, maxK * 2 * M_PI, lk);
 
   // Bivariate vector (2 * K1 * PI, 2 * K2 * PI) for weighting
   arma::vec twokepivec(2);
@@ -169,7 +169,7 @@ arma::vec dTpdWou2D(arma::mat x, arma::mat x0, arma::vec t, arma::vec alpha, arm
   invSigmaA *= 2 * detInvSigmaA;
 
   // For normalizing constants
-  double l2pi = log(2 * PI);
+  double l2pi = log(2 * M_PI);
 
   // Log-normalizing constant for the Gaussian with covariance SigmaA
   double lognormconstSigmaA = -l2pi + 0.5 * log(4 * detInvSigmaA);
@@ -447,7 +447,7 @@ arma::cube rTpdWn2D(arma::uword n, arma::mat x0, arma::vec t, arma::vec mu, arma
 
   // Sequence of winding numbers
   int lk = 2 * maxK + 1;
-  arma::vec twokpi = arma::linspace<arma::vec>(-maxK * 2 * PI, maxK * 2 * PI, lk);
+  arma::vec twokpi = arma::linspace<arma::vec>(-maxK * 2 * M_PI, maxK * 2 * M_PI, lk);
 
   // Bivariate vector (2 * K1 * PI, 2 * K2 * PI) for weighting
   arma::vec twokepivec(2);
@@ -513,7 +513,7 @@ arma::cube rTpdWn2D(arma::uword n, arma::mat x0, arma::vec t, arma::vec mu, arma
   invSigmaA *= 2 * detInvSigmaA;
 
   // For normalizing constants
-  double l2pi = log(2 * PI);
+  double l2pi = log(2 * M_PI);
 
   // Log-normalizing constant for the Gaussian with covariance SigmaA
   double lognormconstSigmaA = -l2pi + 0.5 * log(4 * detInvSigmaA);
@@ -700,7 +700,7 @@ arma::cube rTpdWn2D(arma::uword n, arma::mat x0, arma::vec t, arma::vec mu, arma
   }
 
   // Wrap (convert to [-PI,PI) x [-PI,PI))
-  x -= floor((x + PI) / (2 * PI)) * (2 * PI);
+  x -= floor((x + M_PI) / (2 * M_PI)) * (2 * M_PI);
 
   return x;
 
@@ -756,7 +756,7 @@ arma::vec dStatWn2D(arma::mat x, arma::vec alpha, arma::vec mu, arma::vec sigma,
 
   // Sequence of winding numbers
   int lk = 2 * maxK + 1;
-  arma::vec twokpi = arma::linspace<arma::vec>(-maxK * 2 * PI, maxK * 2 * PI, lk);
+  arma::vec twokpi = arma::linspace<arma::vec>(-maxK * 2 * M_PI, maxK * 2 * M_PI, lk);
 
   // Bivariate vector (2 * K1 * PI, 2 * K2 * PI) for weighting
   arma::vec twokepivec(2);
@@ -788,7 +788,7 @@ arma::vec dStatWn2D(arma::mat x, arma::vec alpha, arma::vec mu, arma::vec sigma,
   arma::mat invSigmaA = 2 * inv_sympd(Sigma) * A;
 
   // For normalizing constants
-  double l2pi = log(2 * PI);
+  double l2pi = log(2 * M_PI);
 
   // Log-determinant of invSigmaA (assumed to be positive)
   double logDetInvSigmaA, sign;
@@ -939,7 +939,7 @@ arma::mat rStatWn2D(arma::uword n, arma::vec mu, arma::vec alpha, arma::vec sigm
   x.each_row() += mu.t();
 
   // Wrap (convert to [-PI,PI) x [-PI,PI))
-  x -= floor((x + PI) / (2 * PI)) * (2 * PI);
+  x -= floor((x + M_PI) / (2 * M_PI)) * (2 * M_PI);
 
   return x;
 

--- a/src/crankNicolson.cpp
+++ b/src/crankNicolson.cpp
@@ -144,7 +144,7 @@ arma::mat crankNicolson1D(arma::mat u0, arma::vec b, arma::vec sigma2, arma::uve
         arma::uword j = ind(i);
         double m = minU(j);
         u.col(j) -= m;
-        u.col(j) /= (1 - m * 2 * PI);
+        u.col(j) /= (1 - m * 2 * M_PI);
 
       }
 
@@ -187,7 +187,7 @@ arma::mat crankNicolson1D(arma::mat u0, arma::vec b, arma::vec sigma2, arma::uve
         arma::uword j = ind(i);
         double m = minU(j);
         u0.col(j) -= m;
-        u0.col(j) /= (1 - m * 2 * PI);
+        u0.col(j) /= (1 - m * 2 * M_PI);
 
       }
 
@@ -441,7 +441,7 @@ arma::mat crankNicolson2D(arma::mat u0, arma::mat bx, arma::mat by, arma::mat si
         arma::uword j = ind(i);
         double m = minU(j);
         u.col(j) -= m;
-        u.col(j) /= (1 - m * 4 * PI * PI);
+        u.col(j) /= (1 - m * 4 * M_PI * M_PI);
 
       }
 
@@ -517,7 +517,7 @@ arma::mat crankNicolson2D(arma::mat u0, arma::mat bx, arma::mat by, arma::mat si
         arma::uword j = ind(i);
         double m = minU(j);
         u0.col(j) -= m;
-        u0.col(j) /= (1 - m * 4 * PI * PI);
+        u0.col(j) /= (1 - m * 4 * M_PI * M_PI);
 
       }
 

--- a/src/drifts.cpp
+++ b/src/drifts.cpp
@@ -24,7 +24,7 @@ arma::vec driftWn1D(arma::vec x, double alpha, double mu, double sigma, int maxK
 
   // Winding numbers
   int lk = 2 * maxK + 1;
-  arma::mat twokpi = arma::linspace<arma::rowvec>(-maxK * 2 * PI, maxK * 2 * PI, lk);
+  arma::mat twokpi = arma::linspace<arma::rowvec>(-maxK * 2 * M_PI, maxK * 2 * M_PI, lk);
 
   // mux
   arma::mat xtwokpi = repmat(x - mu, 1, lk);
@@ -71,7 +71,7 @@ arma::mat driftWn2D(arma::mat x, arma::mat A, arma::vec mu, arma::vec sigma, dou
 
   // Sequence of winding numbers
   int lk = 2 * maxK + 1;
-  arma::vec twokpi = arma::linspace<arma::vec>(-maxK * 2 * PI, maxK * 2 * PI, lk);
+  arma::vec twokpi = arma::linspace<arma::vec>(-maxK * 2 * M_PI, maxK * 2 * M_PI, lk);
 
   // Bivariate vector (2 * K1 * PI, 2 * K2 * PI) for weighting
   arma::vec twokepivec(2);
@@ -90,7 +90,7 @@ arma::mat driftWn2D(arma::mat x, arma::mat A, arma::vec mu, arma::vec sigma, dou
   arma::mat invSigmaA = 2 * inv_sympd(Sigma) * A;
 
   // Log-normalizing constant for the Gaussian with covariance SigmaA
-  double lognormconstSigmaA = -log(2 * PI) + 0.5 * log(det(invSigmaA));
+  double lognormconstSigmaA = -log(2 * M_PI) + 0.5 * log(det(invSigmaA));
 
   /*
    * Weights of the winding numbers for each data point

--- a/src/euler.cpp
+++ b/src/euler.cpp
@@ -77,7 +77,7 @@ arma::mat euler1D(arma::vec x0, double alpha, double mu, double sigma, arma::uwo
     x.col(i) = x.col(i - 1) + drift * delta + Z.subvec(inx0, inx0 + nx0 - 1);
 
     // Convert result to [-PI,PI)
-    x.col(i) -= floor((x.col(i) + PI) / (2 * PI)) * (2 * PI);
+    x.col(i) -= floor((x.col(i) + M_PI) / (2 * M_PI)) * (2 * M_PI);
 
   }
 
@@ -175,7 +175,7 @@ arma::cube euler2D(arma::mat x0, arma::mat A, arma::vec mu, arma::vec sigma, dou
     x.slice(i) = x.slice(i - 1) + drift * delta + Z.rows(inx0, inx0 + nx0 - 1);
 
     // Convert result to [-PI,PI)
-    x.slice(i) -= floor((x.slice(i) + PI) / (2 * PI)) * (2 * PI);
+    x.slice(i) -= floor((x.slice(i) + M_PI) / (2 * M_PI)) * (2 * M_PI);
 
   }
 
@@ -253,7 +253,7 @@ arma::mat stepAheadWn1D(arma::vec x0, double alpha, double mu, double sigma, arm
     x += drift * delta + Z.subvec(iM, iM + Mnx0 - 1);
 
     // Convert result to [-PI, PI)
-    x -= floor((x + PI) / (2 * PI)) * (2 * PI);
+    x -= floor((x + M_PI) / (2 * M_PI)) * (2 * M_PI);
 
   }
 
@@ -357,7 +357,7 @@ arma::cube stepAheadWn2D(arma::mat x0, arma::vec mu, arma::mat A, arma::vec sigm
     x += drift * delta + Z.rows(iM, iM + Mnx0 - 1);
 
     // Convert result to [-PI,PI)
-    x -= floor((x + PI) / (2 * PI)) * (2 * PI) ;
+    x -= floor((x + M_PI) / (2 * M_PI)) * (2 * M_PI) ;
 
   }
 

--- a/src/logLikWouPairs.cpp
+++ b/src/logLikWouPairs.cpp
@@ -68,7 +68,7 @@ double logLikWouPairs(arma::mat x, arma::vec t, arma::vec alpha, arma::vec mu, a
 
   // Sequence of winding numbers
   int lk = 2 * maxK + 1;
-  arma::vec twokpi = arma::linspace<arma::vec>(-maxK * 2 * PI, maxK * 2 * PI, lk);
+  arma::vec twokpi = arma::linspace<arma::vec>(-maxK * 2 * M_PI, maxK * 2 * M_PI, lk);
 
   // Bivariate vector (2 * K1 * PI, 2 * K2 * PI) for weighting
   arma::vec twokepivec(2);
@@ -140,7 +140,7 @@ double logLikWouPairs(arma::mat x, arma::vec t, arma::vec alpha, arma::vec mu, a
   invSigmaA *= 2 * detInvSigmaA;
 
   // For normalizing constants
-  double l2pi = log(2 * PI);
+  double l2pi = log(2 * M_PI);
 
   // Log-normalizing constant for the Gaussian with covariance SigmaA
   double lognormconstSigmaA = -l2pi + 0.5 * log(4 * detInvSigmaA);


### PR DESCRIPTION
Dear Eduardo, dear sdetorus team,

The Rcpp team is trying to move towards defining STRICT_R_HEADERS by default. Please the issue ticket at RcppCore/Rcpp#1158 for motivation and history.

Your package uses (in a few files) PI (instead of the standard C define M_PI, or e.g. the newer Armadillo constant arma::datum::pi) and PI goes away when we set STRICT_R_HEADERS (as a #define in a header or source file, a -DSTRICT_R_HEADERS as a compiler flag, or as a #define in the Rcpp sources as we currently do). We plan to enable STRICT_R_HEADERS by the Jan 2022 release of Rcpp, and will likely offer you a define to suppress it. So if you really do not want the change you can prevent it -- see these lines in Rcpp for details:
https://github.com/RcppCore/Rcpp/blob/e79c70e76bc2a776d2d57287f7192dbdbcb292aa/inst/include/Rcpp/r/headers.h#L28-L38

This very simple PR changes PI to M_PI. Your code will then work with and without STRICT_R_HEADERS (as M_PI is an old define from C). PI only works when STRICT_R_HEADERS is not defined.

As discussed in RcppCore/Rcpp#1158, this is not urgent, but we of course welcome relatively prompt resolution at CRAN so when we continue to test for this (at a likely montly pace) so we do not get false positives as we will continue to use the CRAN set of packages (as opposed to hand-curated set of upstream dev versions).

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.
